### PR TITLE
remove references to develop branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ node {
 String BRANCH = "${env.BRANCH_NAME}"
 
 
-if (BRANCH == "main" || BRANCH == "develop") {
+if (BRANCH == "main") {
     node {
         stage("Deploy to ACC") {
             tryStep "deployment", {


### PR DESCRIPTION
The develop branch was removed from this repo, so this PR removes references to the develop branch in the Jenkinsfile.