### PR TITLE
Remove dependabot assignee

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,3 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
-    assignees:
-      - "RubenSibon"


### PR DESCRIPTION
We should handle maintenance team-wide and not make it an individual responsibility.